### PR TITLE
Add admin mode: only teachers can register/unregister students

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,32 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+security = HTTPBasic()
+
+# Load teacher credentials from JSON file
+def load_teachers():
+    teachers_path = os.path.join(Path(__file__).parent, "teachers.json")
+    with open(teachers_path, "r") as f:
+        return json.load(f)
+
+def is_teacher(credentials: HTTPBasicCredentials = Depends(security)):
+    teachers = load_teachers()
+    for teacher in teachers:
+        if (credentials.username == teacher["username"] and
+            secrets.compare_digest(credentials.password, teacher["password"])):
+            return True
+    raise HTTPException(status_code=401, detail="Unauthorized: Only teachers can perform this action.")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -89,7 +107,7 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, authorized: bool = Depends(is_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +129,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, authorized: bool = Depends(is_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+[
+  {"username": "teacher1", "password": "pass123"},
+  {"username": "teacher2", "password": "teach456"}
+]


### PR DESCRIPTION
Implements admin mode so only teachers (with credentials in teachers.json) can register or unregister students for activities. Students can only view activities and participants.